### PR TITLE
Clarify panel behavior with exit delay configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,9 @@ With:
   <code>null</code> will let the panel use its default value. Setting
   to any other positive value will set that delay. This will not change
   the default behavior of the panel when handled manually, simply what
-  will happen when arming away from Home Assistant through Qolsys Gateway.
+  will happen when arming away from Home Assistant through Qolsys Gateway. 
+  <em>Note that if an exit delay is configured and no door is opened or closed
+  during the delay, the panel will be set to "Arm Stay" instead.</em>
   Defaults to <code>null</code>.</summary>
 
   ```yaml

--- a/README.md
+++ b/README.md
@@ -406,7 +406,8 @@ With:
   to any other positive value will set that delay. This will not change
   the default behavior of the panel when handled manually, simply what
   will happen when arming away from Home Assistant through Qolsys Gateway. 
-  <em>Note that if an exit delay is configured and no door is opened or closed
+  <em>Note that if "Auto Stay" is enabled (may be the default in some cases),
+  an exit delay is configured, and no door is opened or closed
   during the delay, the panel will be set to "Arm Stay" instead.</em>
   Defaults to <code>null</code>.</summary>
 


### PR DESCRIPTION
This was surprising to me, given I filed #14 and how I typically use "Arm Away" from my phone. Figured it'd be worth calling out in the docs.