### PR TITLE
Add support for `arm_stay_exit_delay` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ With:
   <code>null</code> will let the panel use its default value. Setting
   to any other positive value will set that delay. This will not change
   the default behavior of the panel when handled manually, simply what
-  will happen when arming away from Home Assistant through Qolsys Gateway. 
+  will happen when arming away from Home Assistant through Qolsys Gateway.
   <em>Note that if "Auto Stay" is enabled (may be the default in some cases),
   an exit delay is configured, and no door is opened or closed
   during the delay, the panel will be set to "Arm Stay" instead.</em>
@@ -402,6 +402,23 @@ With:
   qolsys_panel:
     # ...
     arm_away_exit_delay: 0 # arming instantly when triggered from Home Assistant, since related to automations
+    # ...
+  ```
+  </details>
+
+- <details><summary><strong>arm_stay_exit_delay:</strong> the delay to set
+  when arming stay through Qolsys Gateway. Setting the value to
+  <code>0</code> will instantly arm the alarm system. Setting to
+  <code>null</code> will let the panel use its default value. Setting
+  to any other positive value will set that delay. This will not change
+  the default behavior of the panel when handled manually, simply what
+  will happen when arming stay from Home Assistant through Qolsys Gateway.
+  Defaults to <code>null</code>.</summary>
+
+  ```yaml
+  qolsys_panel:
+    # ...
+    arm_stay_exit_delay: 10 # arming in 10 seconds when triggered from Home Assistant
     # ...
   ```
   </details>

--- a/apps/qolsysgw/qolsys/actions.py
+++ b/apps/qolsysgw/qolsys/actions.py
@@ -62,22 +62,27 @@ class QolsysActionArm(QolsysAction):
             self._data['usercode'] = str(panel_code)
 
 
+class QolsysActionArmWithDelay(QolsysActionArm):
+    def __init__(self, delay: int = None, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        if delay is not None and delay >= 0:
+            self._data['delay'] = delay
+
+
 class QolsysActionDisarm(QolsysActionArm):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(arm_type=QolsysActionArm.ARMING_TYPE_DISARM,
                          *args, **kwargs)
 
 
-class QolsysActionArmAway(QolsysActionArm):
-    def __init__(self, delay: int = None, *args, **kwargs) -> None:
+class QolsysActionArmAway(QolsysActionArmWithDelay):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(arm_type=QolsysActionArm.ARMING_TYPE_ARM_AWAY,
                          *args, **kwargs)
 
-        if delay is not None and delay >= 0:
-            self._data['delay'] = delay
 
-
-class QolsysActionArmStay(QolsysActionArm):
+class QolsysActionArmStay(QolsysActionArmWithDelay):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(arm_type=QolsysActionArm.ARMING_TYPE_ARM_STAY,
                          *args, **kwargs)

--- a/apps/qolsysgw/qolsys/config.py
+++ b/apps/qolsysgw/qolsys/config.py
@@ -19,6 +19,7 @@ class QolsysGatewayConfig(object):
         'panel_unique_id': 'qolsys_panel',
         'panel_device_name': 'Qolsys Panel',
         'arm_away_exit_delay': None,
+        'arm_stay_exit_delay': None,
 
         'mqtt_namespace': 'mqtt',
         'mqtt_retain': True,

--- a/apps/qolsysgw/qolsys/control.py
+++ b/apps/qolsysgw/qolsys/control.py
@@ -186,11 +186,24 @@ class QolsysControlArmVacation(QolsysControlArmAway):
 
 
 class QolsysControlArmHome(QolsysControlArm):
+    def __init__(self, delay: int = None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._delay = delay
+        self._requires_config = self._requires_config or delay is None
+
+    def configure(self, cfg, state):
+        super().configure(cfg, state)
+
+        if self._delay is None:
+            self._delay = cfg.arm_stay_exit_delay
+
     @property
     def action(self):
         return QolsysActionArmStay(
             partition_id=self._partition_id,
             panel_code=self._panel_code,
+            delay=self._delay,
         )
 
 

--- a/tests/integration/test_gateway_control.py
+++ b/tests/integration/test_gateway_control.py
@@ -233,14 +233,13 @@ class TestQolsysGatewayControl(TestQolsysGatewayBase):
             arming_type='ARM_STAY',
         )
 
-    @pytest.mark.skip(reason='Not implemented yet')
     async def test_control_arm_home_with_exit_delay(self):
         await self._test_control_arming(
             control_action='ARM_HOME',
             partition_status='DISARM',
             arming_type='ARM_STAY',
-            arm_stay_exit_delay=30,
-            expect_delay=30,
+            arm_stay_exit_delay=42,
+            expect_delay=42,
         )
 
     async def test_control_arm_home_secure_arm_with_code(self):


### PR DESCRIPTION
This new parameter allows to define what delay will be used when arming the alarm in ARM_STAY mode, if we want to override the configuration of the panel.

Fixes #5 