### PR TITLE
Show a better error message if missing `mqtt_plugin_cfg`

### DIFF
--- a/apps/qolsysgw/mqtt/exceptions.py
+++ b/apps/qolsysgw/mqtt/exceptions.py
@@ -8,3 +8,7 @@ class UnknownMqttWrapperException(MqttException):
 
 class UnknownDeviceClassException(MqttException):
     pass
+
+
+class MqttPluginUnavailableException(MqttException):
+    pass

--- a/tests/integration/test_gateway.py
+++ b/tests/integration/test_gateway.py
@@ -3,8 +3,25 @@ import asyncio
 import testenv  # noqa: F401
 from testbase import TestQolsysGatewayBase
 
+from gateway import QolsysGateway
+from mqtt.exceptions import MqttPluginUnavailableException
+
 
 class TestQolsysGateway(TestQolsysGatewayBase):
+
+    async def test_gateway_raise_proper_error_if_mqtt_plugin_unavailable(self):
+        # Initialize a gateway instance to connect to that panel
+        gw = QolsysGateway()
+        gw.args = {
+            'panel_host': 'localhost',
+            'panel_token': '<panel_token>',
+        }
+
+        # Override what will be returned as plugins
+        gw.PLUGIN_CONFIG = None
+
+        with self.assertRaises(MqttPluginUnavailableException):
+            await gw.initialize()
 
     async def test_gateway_sends_info_message_on_connection(self):
         panel, gw, info = await self._init_panel_and_gw_and_wait(

--- a/tests/integration/test_gateway_control.py
+++ b/tests/integration/test_gateway_control.py
@@ -1,5 +1,4 @@
 import json
-import pytest
 
 import testenv  # noqa: F401
 from testbase import TestQolsysGatewayBase

--- a/tests/mock_modules/appdaemon/plugins/mqtt/mqttapi.py
+++ b/tests/mock_modules/appdaemon/plugins/mqtt/mqttapi.py
@@ -32,7 +32,10 @@ class ADBase(object):
 class ADAPI(object):
 
     CAPTURED_LOGS = []
-    PLUGIN_CONFIG = {}
+    PLUGIN_CONFIG = {
+        'will_topic': 'appdaemon/birth_and_will',
+        'birth_topic': 'appdaemon/birth_and_will',
+    }
 
     def log(self, msg, *args, **kwargs):
         log = dict(kwargs.items())


### PR DESCRIPTION
If the MQTT Plugin is not properly configured in appdaemon.yaml, the call to get_plugin_config will return None, which was not failing right away but later on when trying to send partition and sensor information to MQTT. This makes it fail earlier, with a clearer error message as an exception.

Fixes #10 