### PR TITLE
Add support for `ERROR` events

### DIFF
--- a/apps/qolsysgw/gateway.py
+++ b/apps/qolsysgw/gateway.py
@@ -227,6 +227,9 @@ class QolsysGateway(Mqtt):
 
             partition.triggered(alarm_type=event.alarm_type)
 
+        else:
+            LOGGER.info(f'UNCAUGHT event {event}; ignored')
+
     async def mqtt_control_callback(self, control: QolsysControl):
         if control.session_token != self._session_token and (
                 self._cfg.user_control_token is None or

--- a/apps/qolsysgw/qolsys/events.py
+++ b/apps/qolsysgw/qolsys/events.py
@@ -305,7 +305,7 @@ class QolsysEventArming(QolsysEvent):
         return (f"<{type(self).__name__} "
                 f"partition_id={self.partition_id} "
                 f"arming_type={self.arming_type} "
-                f"delay{self.delay} "
+                f"delay={self.delay} "
                 f"version={self._version}>")
 
     @classmethod
@@ -367,5 +367,47 @@ class QolsysEventAlarm(QolsysEvent):
         )
 
 
-# class QolsysEventError(QolsysEvent):
-#    pass
+class QolsysEventError(QolsysEvent):
+
+    def __init__(self, partition_id: int, error_type: str, description: str,
+                 version: int, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        self._partition_id = partition_id
+        self._error_type = error_type
+        self._description = description
+        self._version = version
+
+    @property
+    def partition_id(self):
+        return self._partition_id
+
+    @property
+    def error_type(self):
+        return self._error_type
+
+    @property
+    def description(self):
+        return self._description
+
+    def __str__(self):
+        return (f"<{type(self).__name__} "
+                f"partition_id={self.partition_id} "
+                f"error_type={self.error_type} "
+                f"description={self.description} "
+                f"version={self._version}>")
+
+    @classmethod
+    def from_json(cls, data):
+        event_type = data.get('event')
+        if event_type != 'ERROR':
+            raise UnableToParseEventException(f"Cannot parse event '{event_type}'")
+
+        return QolsysEventError(
+            request_id=data.get('requestID'),
+            version=data.get('version'),
+            partition_id=data.get('partition_id'),
+            error_type=data.get('error_type'),
+            description=data.get('description'),
+            raw_event=data,
+        )

--- a/docs/qolsys-panel-interactions.md
+++ b/docs/qolsys-panel-interactions.md
@@ -397,3 +397,32 @@ The `alarm_type` can be one of `POLICE`, `FIRE` or `AUXILIARY`. It can also be
 empty, which is the case when the alarm is triggered by a sensor being `Open`
 while the alarm is armed.
 
+
+### ERROR
+
+The `ERROR` event type happens when an error happens following a command
+sent to the panel through the Control4 interface. This means that any
+operation done directly on the panel (like typing a disarm code physically)
+will not lead to any of those messages.
+
+```json
+{
+  "event": "ERROR",
+  "partition_id": 0,
+  "error_type": "DISARM_FAILED",
+  "description": "Invalid usercode",
+  "version": 1,
+  "requestID": "<request_id>"
+}
+```
+
+The `error_type` corresponds to the type of the error. At the moment, we have
+only observed the following ones:
+- `usercode` which happened when trying to arm/disarm the alarm while the
+  keypad was locked (using partitions), or if the 6-digit usercodes are not
+  enabled on a panel version that requires it
+- `DISARM_FAILED` which happened when trying to arm/disarm the alarm with
+  an invalid usercode
+
+The `description` gives a human-readable version of the `error_type`, which
+contains a bit more information than the `error_type` itself.


### PR DESCRIPTION
At the moment, those events are simply ignored gracefully, and shown as an `INFO` message in the logs.

Fixes #37 