### PR TITLE
Fix issue with the user code format

### DIFF
--- a/apps/qolsysgw/qolsys/config.py
+++ b/apps/qolsysgw/qolsys/config.py
@@ -105,6 +105,12 @@ class QolsysGatewayConfig(object):
                     panel_unique_id=self.get('panel_unique_id') or 'qolsys',
                     discovery_topic=self.get('discovery_topic'))
 
+        # Make sure that user codes are stored as strings
+        for k in ('panel_user_code', 'ha_user_code'):
+            v = self.get(k)
+            if v and not isinstance(v, str):
+                self._override_config[k] = str(v)
+
     def get(self, name):
         value = self._override_config.get(name, self._SENTINEL)
         if value is self._SENTINEL:

--- a/apps/qolsysgw/qolsys/control.py
+++ b/apps/qolsysgw/qolsys/control.py
@@ -22,8 +22,11 @@ class QolsysControl(object):
                  session_token: str = None):
         self._raw = raw
         self._partition_id = partition_id
-        self._code = code
         self._session_token = session_token
+
+        self._code = code
+        if self._code is not None:
+            self._code = str(self._code)
 
         self._requires_config = False
 

--- a/docs/qolsys-panel-interactions.md
+++ b/docs/qolsys-panel-interactions.md
@@ -83,11 +83,6 @@ parameter is not provided, it will simply use the default value configured
 in the panel. If the `delay` is set to `0`, the panel will immediately
 be armed, without an arming period.
 
-  "token": "<token>",
-  "token": "<token>",
-  "token": "<token>",
-  "token": "<token>",
-  "token": "<token>",
 ```json
 {
   "action": "ARMING",

--- a/tests/integration/test_alarm_control_panel_config.py
+++ b/tests/integration/test_alarm_control_panel_config.py
@@ -66,7 +66,7 @@ class TestAlarmControlPanelConfig(TestQolsysGatewayBase):
                 'command_template_code': False,
             },
 
-            panel_user_code='1337',
+            panel_user_code=1337,
         )
 
     async def test_config_code_required_remote_check_num(self):
@@ -79,7 +79,7 @@ class TestAlarmControlPanelConfig(TestQolsysGatewayBase):
                 'command_template_code': True,
             },
 
-            panel_user_code='1337',
+            panel_user_code=1337,
             code_disarm_required=True,
             code_arm_required=True,
             code_trigger_required=True,
@@ -113,7 +113,7 @@ class TestAlarmControlPanelConfig(TestQolsysGatewayBase):
                 'command_template_code': False,
             },
 
-            panel_user_code='1337',
+            panel_user_code=1337,
             code_disarm_required=True,
             code_arm_required=True,
             code_trigger_required=True,
@@ -130,7 +130,7 @@ class TestAlarmControlPanelConfig(TestQolsysGatewayBase):
                 'command_template_code': False,
             },
 
-            panel_user_code='1337',
+            panel_user_code=1337,
             code_disarm_required=True,
             code_arm_required=True,
             code_trigger_required=True,
@@ -148,7 +148,7 @@ class TestAlarmControlPanelConfig(TestQolsysGatewayBase):
                 'command_template_code': True,
             },
 
-            panel_user_code='1337',
+            panel_user_code=1337,
             code_disarm_required=True,
             code_arm_required=True,
             code_trigger_required=True,


### PR DESCRIPTION
If the user code is specified in the YAML configuration as an all-digit value without quotes, it is parsed as an integer, except that we expect to work on a string. This fixes that by making sure that as long as the value we read is not empty, we make sure we will store it as a string.

Fixes #38 