### PR TITLE
♻️ [refactor] deduplicate code in the ARM control classes

### DIFF
--- a/apps/qolsysgw/qolsys/config.py
+++ b/apps/qolsysgw/qolsys/config.py
@@ -120,5 +120,5 @@ class QolsysGatewayConfig(object):
     def __getattr__(self, name):
         value = self.get(name)
         if value is self._SENTINEL:
-            raise AttributeError
+            raise AttributeError(f'Parameter `{name}` has not been defined')
         return value

--- a/apps/qolsysgw/qolsys/control.py
+++ b/apps/qolsysgw/qolsys/control.py
@@ -161,8 +161,6 @@ class QolsysControlArm(_QolsysControlCheckCode):
     _CODE_REQUIRED_ATTR = 'code_arm_required'
     _PANEL_CODE_REQUIRED = 'secure_arm'
 
-
-class QolsysControlArmAway(QolsysControlArm):
     def __init__(self, delay: int = None, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -173,15 +171,20 @@ class QolsysControlArmAway(QolsysControlArm):
         super().configure(cfg, state)
 
         if self._delay is None:
-            self._delay = cfg.arm_away_exit_delay
+            self._delay = getattr(cfg, f'{self._ATTR_PREFIX}_exit_delay')
 
     @property
     def action(self):
-        return QolsysActionArmAway(
+        return self._ACTION_CLASS(
             partition_id=self._partition_id,
             panel_code=self._panel_code,
             delay=self._delay,
         )
+
+
+class QolsysControlArmAway(QolsysControlArm):
+    _ATTR_PREFIX = 'arm_away'
+    _ACTION_CLASS = QolsysActionArmAway
 
 
 class QolsysControlArmVacation(QolsysControlArmAway):
@@ -189,25 +192,8 @@ class QolsysControlArmVacation(QolsysControlArmAway):
 
 
 class QolsysControlArmHome(QolsysControlArm):
-    def __init__(self, delay: int = None, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        self._delay = delay
-        self._requires_config = self._requires_config or delay is None
-
-    def configure(self, cfg, state):
-        super().configure(cfg, state)
-
-        if self._delay is None:
-            self._delay = cfg.arm_stay_exit_delay
-
-    @property
-    def action(self):
-        return QolsysActionArmStay(
-            partition_id=self._partition_id,
-            panel_code=self._panel_code,
-            delay=self._delay,
-        )
+    _ATTR_PREFIX = 'arm_stay'
+    _ACTION_CLASS = QolsysActionArmStay
 
 
 class QolsysControlArmNight(QolsysControlArmHome):


### PR DESCRIPTION
The ARM control classes were sharing the same structure since the `exit_delay` support was added for `ARM_STAY`.
We can thus avoid deduplicating code by moving that logic to the parent class.