### PR TITLE
✨ [feature] Add support for `bypass` parameter when arming

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,63 @@ With:
   ```
   </details>
 
+- <details><summary><strong>arm_away_bypass:</strong> whether or not to
+  bypass sensors that are "open" when arming away through Qolsys Gateway.
+  Bypassed sensors are then ignored until the next time the panel will
+  be armed (this means that closing and reopening those sensors after
+  arming with the bypass will not trigger an alarm).
+  Setting the value to <code>true</code> will always bypass open sensors
+  when arming away, while setting it to <code>false</code> will always
+  disable the bypass. If you have a default behavior for this defined in
+  your panel, this parameter will override it. Leaving the parameter
+  unset will leave the panel decide what to do.
+  Defaults to <code>null</code>.</summary>
+
+  ```yaml
+  qolsys_panel:
+    # ...
+    arm_away_bypass: true # will bypass the open sensors if any
+    # ...
+  ```
+  </details>
+
+- <details><summary><strong>arm_stay_bypass:</strong> whether or not to
+  bypass sensors that are "open" when arming stay through Qolsys Gateway.
+  Bypassed sensors are then ignored until the next time the panel will
+  be armed (this means that closing and reopening those sensors after
+  arming with the bypass will not trigger an alarm).
+  Setting the value to <code>true</code> will always bypass open sensors
+  when arming stay, while setting it to <code>false</code> will always
+  disable the bypass. If you have a default behavior for this defined in
+  your panel, this parameter will override it. Leaving the parameter
+  unset will leave the panel decide what to do.
+  Defaults to <code>null</code>.</summary>
+
+  ```yaml
+  qolsys_panel:
+    # ...
+    arm_stay_bypass: false # will NOT bypass the open sensors if any
+    # ...
+  ```
+  </details>
+
+- <details><summary><strong>arm_type_custom_bypass:</strong> the type of
+  arming to use when using `ARM_CUSTOM_BYPASS` from Home Assistant. This
+  arming type will automatically enable bypassing the open sensors.
+  Setting the value to <code>arm_away</code> will lead to the panel being
+  armed in away mode with bypass enabled when `ARM_CUSTOM_BYPASS` is used.
+  Setting the value to <code>arm_stay</code> will lead to the panel being
+  armed in stay mode.
+  Defaults to <code>arm_away</code>.</summary>
+
+  ```yaml
+  qolsys_panel:
+    # ...
+    arm_type_custom_bypass: arm_stay # to arm the panel in stay mode when using the custom bypass arming type
+    # ...
+  ```
+  </details>
+
 
 #### Optional configuration related to the representation of the panel in Home Assistant
 

--- a/apps/qolsysgw/qolsys/actions.py
+++ b/apps/qolsysgw/qolsys/actions.py
@@ -62,12 +62,16 @@ class QolsysActionArm(QolsysAction):
             self._data['usercode'] = str(panel_code)
 
 
-class QolsysActionArmWithDelay(QolsysActionArm):
-    def __init__(self, delay: int = None, *args, **kwargs) -> None:
+class QolsysActionArmWithDelayAndBypass(QolsysActionArm):
+    def __init__(self, delay: int = None, bypass: bool = None,
+                 *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
         if delay is not None and delay >= 0:
             self._data['delay'] = delay
+
+        if bypass is not None:
+            self._data['bypass'] = str(bypass).lower()
 
 
 class QolsysActionDisarm(QolsysActionArm):
@@ -76,13 +80,13 @@ class QolsysActionDisarm(QolsysActionArm):
                          *args, **kwargs)
 
 
-class QolsysActionArmAway(QolsysActionArmWithDelay):
+class QolsysActionArmAway(QolsysActionArmWithDelayAndBypass):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(arm_type=QolsysActionArm.ARMING_TYPE_ARM_AWAY,
                          *args, **kwargs)
 
 
-class QolsysActionArmStay(QolsysActionArmWithDelay):
+class QolsysActionArmStay(QolsysActionArmWithDelayAndBypass):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(arm_type=QolsysActionArm.ARMING_TYPE_ARM_STAY,
                          *args, **kwargs)

--- a/apps/qolsysgw/qolsys/config.py
+++ b/apps/qolsysgw/qolsys/config.py
@@ -20,6 +20,9 @@ class QolsysGatewayConfig(object):
         'panel_device_name': 'Qolsys Panel',
         'arm_away_exit_delay': None,
         'arm_stay_exit_delay': None,
+        'arm_away_bypass': None,
+        'arm_stay_bypass': None,
+        'arm_type_custom_bypass': 'arm_away',
 
         'mqtt_namespace': 'mqtt',
         'mqtt_retain': True,
@@ -95,6 +98,19 @@ class QolsysGatewayConfig(object):
                     f"{', '.join(valid_trigger)}")
 
             self._override_config['default_trigger_command'] = trig_cmd
+
+        arm_type = self.get('arm_type_custom_bypass')
+        if arm_type:
+            arm_type = arm_type.lower()
+        valid_arm_type = [
+            'arm_stay',
+            'arm_away',
+        ]
+        if arm_type not in valid_arm_type:
+            raise QolsysGwConfigError(
+                f"Invalid arm type '{arm_type}' for custom bypass; must be "
+                f"one of {', '.join(valid_arm_type)}")
+        self._override_config['arm_type_custom_bypass'] = arm_type
 
         # Apply a template to the control and event topics if the unique id
         # is part of the requested topics

--- a/docs/qolsys-panel-interactions.md
+++ b/docs/qolsys-panel-interactions.md
@@ -83,12 +83,18 @@ parameter is not provided, it will simply use the default value configured
 in the panel. If the `delay` is set to `0`, the panel will immediately
 be armed, without an arming period.
 
+We can also use a `bypass` parameter, to specify whether to bypass the
+sensors "open" when arming. If set to `"true"`, the sensors will be
+bypassed and the alarm will be armed. If set to `"false"`, any sensor
+"open" at the time of arming will prevent the system from being armed.
+
 ```json
 {
   "action": "ARMING",
   "arming_type": "ARM_AWAY",
   "partition_id": 0,
   "delay": 10,
+  "bypass": "false",
   "token": "<token>",
   "nonce": "qolsys",
   "source": "C4",


### PR DESCRIPTION
The `ARMING` action of the panel does support a `bypass` parameter which allows to bypass the open sensors when arming. This introduces the support for that parameter in the configuration, as well as the ability to use the `ARM_CUSTOM_BYPASS` service in Home Assistant to arm with the `bypass` enabled.

Fixes #57 