### PR TITLE
🐛 [bugfix] Control commands weren't reading the `delay` and `bypass` parameters

### DIFF
--- a/apps/qolsysgw/qolsys/control.py
+++ b/apps/qolsysgw/qolsys/control.py
@@ -87,11 +87,20 @@ class QolsysControl(object):
                 from_json.__func__ != QolsysControl.from_json.__func__:
             return from_json(data)
 
+        if hasattr(klass, '_EXTRA_PARAMS'):
+            extra_params = {
+                p: data.get(p)
+                for p in klass._EXTRA_PARAMS
+            }
+        else:
+            extra_params = {}
+
         return klass(
             partition_id=data.get('partition_id'),
             code=data.get('code'),
             session_token=data.get('session_token'),
             raw=data,
+            **extra_params,
         )
 
 
@@ -160,6 +169,10 @@ class QolsysControlDisarm(_QolsysControlCheckCode):
 class QolsysControlArm(_QolsysControlCheckCode):
     _CODE_REQUIRED_ATTR = 'code_arm_required'
     _PANEL_CODE_REQUIRED = 'secure_arm'
+    _EXTRA_PARAMS = [
+        'bypass',
+        'delay',
+    ]
 
     def __init__(self, delay: int = None, bypass: bool = None, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -215,7 +228,8 @@ class QolsysControlArmCustomBypass(QolsysControlArm):
     }
 
     def __init__(self, *args, **kwargs):
-        super().__init__(bypass=True, *args, **kwargs)
+        super().__init__(bypass=True, *args,
+                         **{k: v for k, v in kwargs.items() if k != 'bypass'})
 
         self._require_config = True
 

--- a/tests/integration/test_gateway_control.py
+++ b/tests/integration/test_gateway_control.py
@@ -37,6 +37,7 @@ class TestIntegrationQolsysGatewayControl(TestQolsysGatewayBase):
                                    expect_error=None, expect_delay=None,
                                    secure_arm=False, panel_user_code=None,
                                    user_control_token=None, expect_bypass=None,
+                                   send_delay=None, send_bypass=None,
                                    **kwargs):
         panel, gw, _, _ = await self._ready_panel_and_gw(
             partition_ids=[0],
@@ -59,6 +60,10 @@ class TestIntegrationQolsysGatewayControl(TestQolsysGatewayBase):
         }
         if send_code:
             control['code'] = '4242'
+        if send_delay is not None:
+            control['delay'] = send_delay
+        if send_bypass is not None:
+            control['bypass'] = send_bypass
 
         gw.mqtt_publish(
             'homeassistant/alarm_control_panel/qolsys_panel/set',
@@ -172,6 +177,15 @@ class TestIntegrationQolsysGatewayControl(TestQolsysGatewayBase):
             expect_delay=30,
         )
 
+    async def test_integration_control_arm_away_with_exit_delay_if_sent(self):
+        await self._test_control_arming(
+            control_action='ARM_AWAY',
+            partition_status='DISARM',
+            arming_type='ARM_AWAY',
+            send_delay=30,
+            expect_delay=30,
+        )
+
     async def test_integration_control_arm_away_secure_arm_with_code(self):
         await self._test_control_arming(
             secure_arm=True,
@@ -240,6 +254,24 @@ class TestIntegrationQolsysGatewayControl(TestQolsysGatewayBase):
             expect_bypass='false',
         )
 
+    async def test_integration_control_arm_away_bypass_true_if_sent(self):
+        await self._test_control_arming(
+            control_action='ARM_AWAY',
+            partition_status='DISARM',
+            arming_type='ARM_AWAY',
+            send_bypass=True,
+            expect_bypass='true',
+        )
+
+    async def test_integration_control_arm_away_bypass_false_if_sent(self):
+        await self._test_control_arming(
+            control_action='ARM_AWAY',
+            partition_status='DISARM',
+            arming_type='ARM_AWAY',
+            send_bypass=False,
+            expect_bypass='false',
+        )
+
     async def test_integration_control_arm_vacation(self):
         await self._test_control_arming(
             control_action='ARM_VACATION',
@@ -260,6 +292,15 @@ class TestIntegrationQolsysGatewayControl(TestQolsysGatewayBase):
             partition_status='DISARM',
             arming_type='ARM_STAY',
             arm_stay_exit_delay=42,
+            expect_delay=42,
+        )
+
+    async def test_integration_control_arm_home_with_exit_delay_if_sent(self):
+        await self._test_control_arming(
+            control_action='ARM_HOME',
+            partition_status='DISARM',
+            arming_type='ARM_STAY',
+            send_delay=42,
             expect_delay=42,
         )
 
@@ -306,6 +347,24 @@ class TestIntegrationQolsysGatewayControl(TestQolsysGatewayBase):
             partition_status='DISARM',
             arming_type='ARM_STAY',
             arm_stay_bypass=False,
+            expect_bypass='false',
+        )
+
+    async def test_integration_control_arm_home_bypass_true_if_sent(self):
+        await self._test_control_arming(
+            control_action='ARM_HOME',
+            partition_status='DISARM',
+            arming_type='ARM_STAY',
+            send_bypass=True,
+            expect_bypass='true',
+        )
+
+    async def test_integration_control_arm_home_bypass_false_if_sent(self):
+        await self._test_control_arming(
+            control_action='ARM_HOME',
+            partition_status='DISARM',
+            arming_type='ARM_STAY',
+            send_bypass=False,
             expect_bypass='false',
         )
 


### PR DESCRIPTION
We had support for overriding `delay` and `bypass` when receiving a control command, which could be done in an Home Assistant automation for instance to have more control over what `qolsysgw` supports but that might not be exposable directly to Home Assistant. However, the parameters received from the control command were never read, and thus simply ignored. This fixes that.