### PR TITLE
✨ [feature] disable by default entities that do not update

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,6 +633,23 @@ With:
   ```
   </details>
 
+- <details><summary><strong>enable_static_sensors_by_default:</strong>
+  whether or not sensors that will not be updated by the panel (e.g. Bluetooth)
+  should be enabled by default in Home Assistant. Even if setting this to
+  <code>false</code>, you will have the ability to enable them on a
+  sensor-by-sensor basis in Home Assistant. If setting it to <code>true</code>,
+  you will also be able to disable them on a sensor-by-sensor basis in
+  Home Assistant.
+  Defaults to <code>false</code>.</summary>
+
+  ```yaml
+  qolsys_panel:
+    # ...
+    enable_static_sensors_by_default: true
+    # ...
+  ```
+  </details>
+
 
 #### Optional configuration related to MQTT & AppDaemon
 

--- a/apps/qolsysgw/mqtt/updater.py
+++ b/apps/qolsysgw/mqtt/updater.py
@@ -18,6 +18,7 @@ from qolsys.sensors import QolsysSensorHeat
 from qolsys.sensors import QolsysSensorMotion
 from qolsys.sensors import QolsysSensorSmokeDetector
 from qolsys.sensors import QolsysSensorWater
+from qolsys.sensors import _QolsysSensorWithoutUpdates
 from qolsys.state import QolsysState
 from qolsys.utils import defaultLoggerCallback
 from qolsys.utils import find_subclass
@@ -477,6 +478,10 @@ class MqttWrapperQolsysSensor(MqttWrapper):
             'availability_mode': 'all',
             'availability': self.configure_availability,
             'json_attributes_topic': self.attributes_topic,
+            'enabled_by_default': (
+                self._cfg.enable_static_sensors_by_default or
+                not isinstance(self._sensor, _QolsysSensorWithoutUpdates)
+            ),
         }
 
         # As we have a unique ID for the panel, we can setup a unique ID for

--- a/apps/qolsysgw/qolsys/config.py
+++ b/apps/qolsysgw/qolsys/config.py
@@ -39,6 +39,7 @@ class QolsysGatewayConfig(object):
         'code_trigger_required': False,
         'default_trigger_command': None,
         'default_sensor_device_class': 'safety',
+        'enable_static_sensors_by_default': False,
     }
 
     def __init__(self, args=None, check=True):

--- a/apps/qolsysgw/qolsys/sensors.py
+++ b/apps/qolsysgw/qolsys/sensors.py
@@ -189,6 +189,10 @@ class QolsysSensor(QolsysObservable):
         return cls(**common)
 
 
+class _QolsysSensorWithoutUpdates(QolsysSensor):
+    pass
+
+
 class QolsysSensorDoorWindow(QolsysSensor):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
@@ -228,7 +232,7 @@ class QolsysSensorPanelGlassBreak(QolsysSensorGlassBreak):
         return cls.from_json_subclass('Panel Glass Break', data, common)
 
 
-class QolsysSensorBluetooth(QolsysSensor):
+class QolsysSensorBluetooth(_QolsysSensorWithoutUpdates):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 

--- a/tests/end-to-end/fixtures/appdaemon/apps/apps.yaml.jinja
+++ b/tests/end-to-end/fixtures/appdaemon/apps/apps.yaml.jinja
@@ -5,3 +5,4 @@ qolsys_panel:
   panel_host: {% if IN_WSL %}host.docker.internal{% else %}localhost{% endif %}
   panel_port: {{ PANEL_PORT }}
   panel_token: ThisIsMyToken
+  enable_static_sensors_by_default: true

--- a/tests/integration/test_qolsys_events.py
+++ b/tests/integration/test_qolsys_events.py
@@ -115,7 +115,8 @@ class TestIntegrationQolsysEvents(TestQolsysGatewayBase):
             )
 
     async def _check_sensor_mqtt_messages(self, gw, sensor_flat_name,
-                                          sensor_state, expected_device_class):
+                                          sensor_state, expected_device_class,
+                                          expected_enabled_by_default=True):
         state = sensor_state
 
         mqtt_prefix = f'homeassistant/binary_sensor/{sensor_flat_name}'
@@ -158,6 +159,7 @@ class TestIntegrationQolsysEvents(TestQolsysGatewayBase):
                     'unique_id': (f'qolsys_panel_p{state.partition_id}'
                                   f'z{state.zone_id}'),
                     'device': mock.ANY,
+                    'enabled_by_default': expected_enabled_by_default,
                 },
                 json.loads(mqtt_config['payload']),
             )
@@ -284,6 +286,7 @@ class TestIntegrationQolsysEvents(TestQolsysGatewayBase):
                 sensor_flat_name='my_door',
                 sensor_state=sensor100,
                 expected_device_class='door',
+                expected_enabled_by_default=True,
             )
 
         with self.subTest(msg='Sensor 101 is properly configured'):
@@ -305,6 +308,7 @@ class TestIntegrationQolsysEvents(TestQolsysGatewayBase):
                 sensor_flat_name='my_window',
                 sensor_state=sensor101,
                 expected_device_class='door',
+                expected_enabled_by_default=True,
             )
 
         with self.subTest(msg='Sensor 110 is properly configured'):
@@ -326,6 +330,7 @@ class TestIntegrationQolsysEvents(TestQolsysGatewayBase):
                 sensor_flat_name='my_motion',
                 sensor_state=sensor110,
                 expected_device_class='motion',
+                expected_enabled_by_default=True,
             )
 
         with self.subTest(msg='Sensor 111 is properly configured'):
@@ -347,6 +352,7 @@ class TestIntegrationQolsysEvents(TestQolsysGatewayBase):
                 sensor_flat_name='panel_motion',
                 sensor_state=sensor111,
                 expected_device_class='motion',
+                expected_enabled_by_default=True,
             )
 
         with self.subTest(msg='Sensor 120 is properly configured'):
@@ -368,6 +374,7 @@ class TestIntegrationQolsysEvents(TestQolsysGatewayBase):
                 sensor_flat_name='my_glass_break',
                 sensor_state=sensor120,
                 expected_device_class='vibration',
+                expected_enabled_by_default=True,
             )
 
         with self.subTest(msg='Sensor 121 is properly configured'):
@@ -389,6 +396,7 @@ class TestIntegrationQolsysEvents(TestQolsysGatewayBase):
                 sensor_flat_name='panel_glass_break',
                 sensor_state=sensor121,
                 expected_device_class='vibration',
+                expected_enabled_by_default=True,
             )
 
         with self.subTest(msg='Sensor 130 is properly configured'):
@@ -410,6 +418,7 @@ class TestIntegrationQolsysEvents(TestQolsysGatewayBase):
                 sensor_flat_name='my_phone',
                 sensor_state=sensor130,
                 expected_device_class='presence',
+                expected_enabled_by_default=False,
             )
 
         with self.subTest(msg='Sensor 140 is properly configured'):
@@ -431,6 +440,7 @@ class TestIntegrationQolsysEvents(TestQolsysGatewayBase):
                 sensor_flat_name='my_smoke_detector',
                 sensor_state=sensor140,
                 expected_device_class='smoke',
+                expected_enabled_by_default=True,
             )
 
         with self.subTest(msg='Sensor 141 is properly configured'):
@@ -452,6 +462,7 @@ class TestIntegrationQolsysEvents(TestQolsysGatewayBase):
                 sensor_flat_name='my_co_detector',
                 sensor_state=sensor141,
                 expected_device_class='gas',
+                expected_enabled_by_default=True,
             )
 
         with self.subTest(msg='Sensor 150 is properly configured'):
@@ -473,6 +484,7 @@ class TestIntegrationQolsysEvents(TestQolsysGatewayBase):
                 sensor_flat_name='my_water_detector',
                 sensor_state=sensor150,
                 expected_device_class='moisture',
+                expected_enabled_by_default=True,
             )
 
         with self.subTest(msg='Sensor 200 is properly configured'):
@@ -494,6 +506,7 @@ class TestIntegrationQolsysEvents(TestQolsysGatewayBase):
                 sensor_flat_name='my_2nd_door',
                 sensor_state=sensor200,
                 expected_device_class='door',
+                expected_enabled_by_default=True,
             )
 
         with self.subTest(msg='Sensor 210 is properly configured'):
@@ -515,6 +528,7 @@ class TestIntegrationQolsysEvents(TestQolsysGatewayBase):
                 sensor_flat_name='my_freeze_sensor',
                 sensor_state=sensor210,
                 expected_device_class='cold',
+                expected_enabled_by_default=True,
             )
 
         with self.subTest(msg='Sensor 220 is properly configured'):
@@ -536,6 +550,7 @@ class TestIntegrationQolsysEvents(TestQolsysGatewayBase):
                 sensor_flat_name='my_heat_sensor',
                 sensor_state=sensor220,
                 expected_device_class='heat',
+                expected_enabled_by_default=True,
             )
 
     async def _test_integration_event_info_secure_arm(self, from_secure_arm,
@@ -867,6 +882,7 @@ class TestIntegrationQolsysEvents(TestQolsysGatewayBase):
                 {
                     'name': 'My Motion',
                     'device_class': 'motion',
+                    'enabled_by_default': True,
                     'state_topic': 'homeassistant/binary_sensor/'
                                    'my_motion/state',
                     'payload_on': 'Open',

--- a/tests/unit/qolsysgw/mqtt/test_updater.py
+++ b/tests/unit/qolsysgw/mqtt/test_updater.py
@@ -435,6 +435,7 @@ class TestUnitMqttWrapperQolsys(unittest.TestCase):
                 'name': 'Qolsys Panel',
             },
             'device_class': 'safety',
+            'enabled_by_default': True,
             'json_attributes_topic': ('homeassistant/binary_sensor/'
                                       'testsensor/attributes'),
             'name': 'TestSensor',


### PR DESCRIPTION
Entities such as 'bluetooth' devices are declared as sensors but do not seem to receive updates from the panel after that. We can thus simply disable those by default, allowing people that want to see them to enable them on a sensor-by-sensor basis, or even enable all of them thanks to a new configuration option
`enable_static_sensors_by_default` that can be set to `true`.

Fixes #67 