### PR TITLE
✨ [feature] Add support for tampered sensors

### DIFF
--- a/docs/qolsys-panel-interactions.md
+++ b/docs/qolsys-panel-interactions.md
@@ -303,6 +303,18 @@ new status (open vs. closed).
 ```
 
 
+##### Special case: sensor tampering
+
+The `ZONE_ACTIVE` zone event type is also used by the panel to indicate that
+a sensor has been tampered with, or has been restored. The following behaviors
+have been identified:
+
+- `Open` and `Closed` have two layers for any given sensor:
+   - An `Open` sensor being `Open` through `ZONE_ACTIVE` is now tampered
+   - A tampered sensor being `Closed` through `ZONE_ACTIVE` is no more tampered
+- Receiving two `ZONE_ACTIVE` for the same tampered sensor in the same second, the first `Open` and the second `Closed`, means the sensor is no more tampered, and the next `ZONE_ACTIVE` message indicates the current status of the sensor (whether it is currently `Open` or `Closed`)
+
+
 #### ZONE_UPDATE
 
 This event happens when a sensor was altered and is back in service, but also

--- a/tests/end-to-end/test_qolsysgw.py
+++ b/tests/end-to-end/test_qolsysgw.py
@@ -229,6 +229,7 @@ class TestEndtoendQolsysGw(unittest.IsolatedAsyncioTestCase):
                     'zone_alarm_type': 3,
                     'zone_physical_type': 1,
                     'zone_type': 1,
+                    'tampered': False,
                 },
                 'entity_id': 'binary_sensor.my_door',
                 'state': 'off',
@@ -241,6 +242,7 @@ class TestEndtoendQolsysGw(unittest.IsolatedAsyncioTestCase):
                     'zone_alarm_type': 3,
                     'zone_physical_type': 1,
                     'zone_type': 1,
+                    'tampered': False,
                 },
                 'entity_id': 'binary_sensor.my_window',
                 'state': 'on',
@@ -253,6 +255,7 @@ class TestEndtoendQolsysGw(unittest.IsolatedAsyncioTestCase):
                     'zone_alarm_type': 3,
                     'zone_physical_type': 2,
                     'zone_type': 2,
+                    'tampered': False,
                 },
                 'entity_id': 'binary_sensor.my_motion',
                 'state': 'off',
@@ -265,6 +268,7 @@ class TestEndtoendQolsysGw(unittest.IsolatedAsyncioTestCase):
                     'zone_alarm_type': 3,
                     'zone_physical_type': 1,
                     'zone_type': 119,
+                    'tampered': False,
                 },
                 'entity_id': 'binary_sensor.panel_motion',
                 'state': 'off',
@@ -277,6 +281,7 @@ class TestEndtoendQolsysGw(unittest.IsolatedAsyncioTestCase):
                     'zone_alarm_type': 0,
                     'zone_physical_type': 1,
                     'zone_type': 116,
+                    'tampered': False,
                 },
                 'entity_id': 'binary_sensor.my_glass_break',
                 'state': 'off',
@@ -289,6 +294,7 @@ class TestEndtoendQolsysGw(unittest.IsolatedAsyncioTestCase):
                     'zone_alarm_type': 0,
                     'zone_physical_type': 1,
                     'zone_type': 116,
+                    'tampered': False,
                 },
                 'entity_id': 'binary_sensor.panel_glass_break',
                 'state': 'off',
@@ -301,6 +307,7 @@ class TestEndtoendQolsysGw(unittest.IsolatedAsyncioTestCase):
                     'zone_alarm_type': 1,
                     'zone_physical_type': 1,
                     'zone_type': 115,
+                    'tampered': False,
                 },
                 'entity_id': 'binary_sensor.my_phone',
                 'state': 'off',
@@ -313,6 +320,7 @@ class TestEndtoendQolsysGw(unittest.IsolatedAsyncioTestCase):
                     'zone_alarm_type': 9,
                     'zone_physical_type': 9,
                     'zone_type': 5,
+                    'tampered': False,
                 },
                 'entity_id': 'binary_sensor.my_smoke_detector',
                 'state': 'off',
@@ -325,6 +333,7 @@ class TestEndtoendQolsysGw(unittest.IsolatedAsyncioTestCase):
                     'zone_alarm_type': 3,
                     'zone_physical_type': 1,
                     'zone_type': 1,
+                    'tampered': False,
                 },
                 'entity_id': 'binary_sensor.my_co_detector',
                 'state': 'off',
@@ -337,6 +346,7 @@ class TestEndtoendQolsysGw(unittest.IsolatedAsyncioTestCase):
                     'zone_alarm_type': 0,
                     'zone_physical_type': 8,
                     'zone_type': 15,
+                    'tampered': False,
                 },
                 'entity_id': 'binary_sensor.my_water_detector',
                 'state': 'off',
@@ -366,6 +376,7 @@ class TestEndtoendQolsysGw(unittest.IsolatedAsyncioTestCase):
                     'zone_alarm_type': 3,
                     'zone_physical_type': 1,
                     'zone_type': 1,
+                    'tampered': False,
                 },
                 'entity_id': 'binary_sensor.my_2nd_door',
                 'state': 'off',
@@ -378,6 +389,7 @@ class TestEndtoendQolsysGw(unittest.IsolatedAsyncioTestCase):
                     'zone_alarm_type': 0,
                     'zone_physical_type': 6,
                     'zone_type': 17,
+                    'tampered': False,
                 },
                 'entity_id': 'binary_sensor.my_freeze_sensor',
                 'state': 'off',
@@ -390,6 +402,7 @@ class TestEndtoendQolsysGw(unittest.IsolatedAsyncioTestCase):
                     'zone_alarm_type': 0,
                     'zone_physical_type': 10,
                     'zone_type': 8,
+                    'tampered': False,
                 },
                 'entity_id': 'binary_sensor.my_heat_sensor',
                 'state': 'off',
@@ -417,30 +430,43 @@ class TestEndtoendQolsysGw(unittest.IsolatedAsyncioTestCase):
         closed_entities = [100, 110, 111, 120, 121, 130, 140, 141, 150,
                            200, 210, 220]
         open_entities = [101]
+        tamper_entities = [100, 110, 111, 210]
+        untamper_entities_to_open = [100]
+        untamper_entities_to_closed_short = [110]
+        untamper_entities_to_closed_long = [111]
 
-        for zone_id in closed_entities:
-            events.append({
+        def zone_active_event(zone_id, closed=False):
+            return {
                 'event': 'ZONE_EVENT',
                 'zone_event_type': 'ZONE_ACTIVE',
                 'version': 1,
                 'zone': {
                     'zone_id': zone_id,
-                    'status': 'Open',
+                    'status': 'Closed' if closed else 'Open',
                 },
                 'requestID': '<request_id>',
-            })
+            }
+
+        for zone_id in closed_entities + tamper_entities:
+            events.append(zone_active_event(zone_id, closed=False))
 
         for zone_id in open_entities:
-            events.append({
-                'event': 'ZONE_EVENT',
-                'zone_event_type': 'ZONE_ACTIVE',
-                'version': 1,
-                'zone': {
-                    'zone_id': zone_id,
-                    'status': 'Closed',
-                },
-                'requestID': '<request_id>',
-            })
+            events.append(zone_active_event(zone_id, closed=True))
+
+        for zone_id in untamper_entities_to_closed_short:
+            events.append(zone_active_event(zone_id, closed=True))
+            events.append(zone_active_event(zone_id, closed=True))
+
+        for zone_id in untamper_entities_to_open + untamper_entities_to_closed_long:
+            # Open then closed in the same second = not anymore tampered
+            events.append(zone_active_event(zone_id, closed=False))
+            events.append(zone_active_event(zone_id, closed=True))
+
+        for zone_id in untamper_entities_to_open:
+            events.append(zone_active_event(zone_id, closed=False))
+
+        for zone_id in untamper_entities_to_closed_long:
+            events.append(zone_active_event(zone_id, closed=True))
 
         events.append({
             'event': 'ARMING',
@@ -518,6 +544,7 @@ class TestEndtoendQolsysGw(unittest.IsolatedAsyncioTestCase):
                     'zone_alarm_type': 3,
                     'zone_physical_type': 1,
                     'zone_type': 1,
+                    'tampered': False,
                 },
                 'entity_id': 'binary_sensor.my_door',
                 'state': 'on',
@@ -530,6 +557,7 @@ class TestEndtoendQolsysGw(unittest.IsolatedAsyncioTestCase):
                     'zone_alarm_type': 3,
                     'zone_physical_type': 1,
                     'zone_type': 1,
+                    'tampered': False,
                 },
                 'entity_id': 'binary_sensor.my_window',
                 'state': 'off',
@@ -542,9 +570,10 @@ class TestEndtoendQolsysGw(unittest.IsolatedAsyncioTestCase):
                     'zone_alarm_type': 3,
                     'zone_physical_type': 2,
                     'zone_type': 2,
+                    'tampered': False,
                 },
                 'entity_id': 'binary_sensor.my_motion',
-                'state': 'on',
+                'state': 'off',
             },
             {
                 'attributes': {
@@ -554,9 +583,10 @@ class TestEndtoendQolsysGw(unittest.IsolatedAsyncioTestCase):
                     'zone_alarm_type': 3,
                     'zone_physical_type': 1,
                     'zone_type': 119,
+                    'tampered': False,
                 },
                 'entity_id': 'binary_sensor.panel_motion',
-                'state': 'on',
+                'state': 'off',
             },
             {
                 'attributes': {
@@ -566,6 +596,7 @@ class TestEndtoendQolsysGw(unittest.IsolatedAsyncioTestCase):
                     'zone_alarm_type': 0,
                     'zone_physical_type': 1,
                     'zone_type': 116,
+                    'tampered': False,
                 },
                 'entity_id': 'binary_sensor.my_glass_break',
                 'state': 'on',
@@ -578,6 +609,7 @@ class TestEndtoendQolsysGw(unittest.IsolatedAsyncioTestCase):
                     'zone_alarm_type': 0,
                     'zone_physical_type': 1,
                     'zone_type': 116,
+                    'tampered': False,
                 },
                 'entity_id': 'binary_sensor.panel_glass_break',
                 'state': 'on',
@@ -590,6 +622,7 @@ class TestEndtoendQolsysGw(unittest.IsolatedAsyncioTestCase):
                     'zone_alarm_type': 1,
                     'zone_physical_type': 1,
                     'zone_type': 115,
+                    'tampered': False,
                 },
                 'entity_id': 'binary_sensor.my_phone',
                 'state': 'on',
@@ -602,6 +635,7 @@ class TestEndtoendQolsysGw(unittest.IsolatedAsyncioTestCase):
                     'zone_alarm_type': 9,
                     'zone_physical_type': 9,
                     'zone_type': 5,
+                    'tampered': False,
                 },
                 'entity_id': 'binary_sensor.my_smoke_detector',
                 'state': 'on',
@@ -614,6 +648,7 @@ class TestEndtoendQolsysGw(unittest.IsolatedAsyncioTestCase):
                     'zone_alarm_type': 3,
                     'zone_physical_type': 1,
                     'zone_type': 1,
+                    'tampered': False,
                 },
                 'entity_id': 'binary_sensor.my_co_detector',
                 'state': 'on',
@@ -626,6 +661,7 @@ class TestEndtoendQolsysGw(unittest.IsolatedAsyncioTestCase):
                     'zone_alarm_type': 0,
                     'zone_physical_type': 8,
                     'zone_type': 15,
+                    'tampered': False,
                 },
                 'entity_id': 'binary_sensor.my_water_detector',
                 'state': 'on',
@@ -655,6 +691,7 @@ class TestEndtoendQolsysGw(unittest.IsolatedAsyncioTestCase):
                     'zone_alarm_type': 3,
                     'zone_physical_type': 1,
                     'zone_type': 1,
+                    'tampered': False,
                 },
                 'entity_id': 'binary_sensor.my_2nd_door',
                 'state': 'on',
@@ -667,6 +704,7 @@ class TestEndtoendQolsysGw(unittest.IsolatedAsyncioTestCase):
                     'zone_alarm_type': 0,
                     'zone_physical_type': 6,
                     'zone_type': 17,
+                    'tampered': True,
                 },
                 'entity_id': 'binary_sensor.my_freeze_sensor',
                 'state': 'on',
@@ -679,6 +717,7 @@ class TestEndtoendQolsysGw(unittest.IsolatedAsyncioTestCase):
                     'zone_alarm_type': 0,
                     'zone_physical_type': 10,
                     'zone_type': 8,
+                    'tampered': False,
                 },
                 'entity_id': 'binary_sensor.my_heat_sensor',
                 'state': 'on',

--- a/tests/integration/test_alarm_control_panel_config.py
+++ b/tests/integration/test_alarm_control_panel_config.py
@@ -42,8 +42,7 @@ class TestIntegrationAlarmControlPanelConfig(TestQolsysGatewayBase):
         if payload_expect['command_template_code']:
             expected_command_template['code'] = '{{ code }}'
 
-        command_template = json.loads(payload['command_template'])
-        self.assertDictEqual(expected_command_template, command_template)
+        self.assertJsonDictEqual(expected_command_template, payload['command_template'])
 
     async def test_integration_config_default(self):
         await self._test_config(

--- a/tests/integration/test_gateway.py
+++ b/tests/integration/test_gateway.py
@@ -1,5 +1,4 @@
 import asyncio
-import json
 
 import testenv  # noqa: F401
 from testbase import TestQolsysGatewayBase
@@ -73,12 +72,12 @@ class TestIntegrationQolsysGateway(TestQolsysGatewayBase):
         )
 
         self.assertEqual(ISODATE, state['payload'])
-        self.assertDictEqual(
+        self.assertJsonDictEqual(
             {
                 'type': 'UnknownQolsysEventException',
                 'desc': f'Event type not found for event {data}',
             },
-            json.loads(attributes['payload']),
+            attributes['payload'],
         )
 
     async def test_integration_gateway_stays_connected_on_unknown_event_type(self):
@@ -111,10 +110,10 @@ class TestIntegrationQolsysGateway(TestQolsysGatewayBase):
         )
 
         self.assertEqual(ISODATE, state['payload'])
-        self.assertDictEqual(
+        self.assertJsonDictEqual(
             {
                 'type': 'UnknownQolsysEventException',
                 'desc': f"Event type '{data['event']}' unsupported for event {data}",
             },
-            json.loads(attributes['payload']),
+            attributes['payload'],
         )

--- a/tests/integration/testbase.py
+++ b/tests/integration/testbase.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 
 import testenv  # noqa: F401
@@ -11,6 +12,19 @@ from qolsys.config import QolsysGatewayConfig
 class TestQolsysGatewayBase(unittest.IsolatedAsyncioTestCase):
 
     _TIMEOUT = .1
+
+    def assertJsonDictEqual(self, expected, actual):
+        if not isinstance(actual, dict):
+            actual = json.loads(actual)
+
+        self.assertDictEqual(expected, actual)
+
+    def assertJsonSubDictEqual(self, expected, actual):
+        if not isinstance(actual, dict):
+            actual = json.loads(actual)
+
+        actual_subset = {k: v for k, v in actual.items() if k in expected}
+        self.assertDictEqual(expected, actual_subset)
 
     async def _init_panel_and_gw(self, **kwargs):
         # Start a panel panel


### PR DESCRIPTION
This adds a `tampered` attribute to sensors indicating if the sensor is currently believed to be tampered with or not.

This is not 100% accurate as it depends on specific sets of events that the panel is sending in a given order, which allow to guess if a sensor is currently tampered or not. This should be taken with a huge grain of salt as, for instance, we do not have that information when getting the summary state for the sensors from the panel (and will be able to know a sensor was tampered when it won't be tampered anymore).

More details are available at https://github.com/XaF/qolsysgw/issues/73 as to the identified interactions and how they are implemented here.

Fixes #73 