### PR TITLE
🐛 [bugfix] handle properly when to require a user code from HA

### DIFF
--- a/apps/qolsysgw/qolsys/control.py
+++ b/apps/qolsysgw/qolsys/control.py
@@ -118,12 +118,10 @@ class _QolsysControlCheckCode(QolsysControl):
         if self._PANEL_CODE_REQUIRED == 'secure_arm':
             self._PANEL_CODE_REQUIRED = self._secure_arm
 
-        self._code_required = getattr(cfg, self._CODE_REQUIRED_ATTR) or \
-            self._PANEL_CODE_REQUIRED
-
         self._panel_code = cfg.panel_user_code
 
-        self._check_code = self._code_required and not cfg.ha_check_user_code
+        code_required_from_ha = getattr(cfg, self._CODE_REQUIRED_ATTR)
+        self._check_code = code_required_from_ha and not cfg.ha_check_user_code
         if self._check_code:
             self._valid_code = cfg.ha_user_code or cfg.panel_user_code
 

--- a/tests/integration/test_gateway_control.py
+++ b/tests/integration/test_gateway_control.py
@@ -130,6 +130,16 @@ class TestIntegrationQolsysGatewayControl(TestQolsysGatewayBase):
             panel_user_code='1337',
         )
 
+    async def test_integration_control_disarm_with_panel_code_no_disarm_code_required_no_ha_check_user_code(self):
+        await self._test_control_arming(
+            control_action='DISARM',
+            partition_status='ARM_AWAY',
+            arming_type='DISARM',
+            panel_user_code='1337',
+            code_disarm_required=False,
+            ha_check_user_code=False,
+        )
+
     async def test_integration_control_disarm_with_panel_code_and_user_control_token(self):
         await self._test_control_arming(
             control_action='DISARM',


### PR DESCRIPTION
The gateway was expecting a user code from Home Assistant as soon as a code was required for the action to be performed. However, when a panel code is defined in the gateway configuration, this code might not be required if not specifically required by the `code_*_required` flags. This fixes that.

Fixes #79