### PR TITLE
build: 👷 try fixing panel port for CI runs

### DIFF
--- a/tests/end-to-end/test_qolsysgw.py
+++ b/tests/end-to-end/test_qolsysgw.py
@@ -99,7 +99,7 @@ class TestEndtoendQolsysGw(unittest.IsolatedAsyncioTestCase):
         # Sometimes there's weird issues with ports, give it a few tries
         for i in reversed(range(10)):
             # Try starting the panel
-            await panel.start()
+            await panel.start(port=12345 if running_in_ci() else 0)
 
             # Check that we can connect to it
             try:


### PR DESCRIPTION
Trying to avoid end-to-end tests failing regularly.