### PR TITLE
Fix sensors stuck open after a false tamper detection, add tamper detection opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,6 +650,23 @@ With:
   ```
   </details>
 
+- <details><summary><strong>enable_sensor_tamper_detection:</strong>
+  whether or not a sensor should be flagged as tampered when the panel reports
+  it as open while it is already open. Some setups, such as zones sharing a
+  hardwire module or multi-input sensors, receive repeated open messages that
+  are not tamper events, which can leave sensors wrongly reported as tampered
+  or open. Setting this to <code>false</code> makes those messages only update
+  the status of the sensor.
+  Defaults to <code>true</code>.</summary>
+
+  ```yaml
+  qolsys_panel:
+    # ...
+    enable_sensor_tamper_detection: false
+    # ...
+  ```
+  </details>
+
 
 #### Optional configuration related to MQTT & AppDaemon
 

--- a/apps/qolsysgw/gateway.py
+++ b/apps/qolsysgw/gateway.py
@@ -248,7 +248,10 @@ class QolsysGateway(Mqtt):
             LOGGER.debug(f'ACTIVE zone={event.zone}')
 
             if event.zone.status.lower() == 'open':
-                self._state.zone_open(event.zone.id)
+                self._state.zone_open(
+                    event.zone.id,
+                    detect_tamper=self._cfg.enable_sensor_tamper_detection,
+                )
             else:
                 self._state.zone_closed(event.zone.id)
 

--- a/apps/qolsysgw/qolsys/config.py
+++ b/apps/qolsysgw/qolsys/config.py
@@ -40,6 +40,7 @@ class QolsysGatewayConfig(object):
         'default_trigger_command': None,
         'default_sensor_device_class': 'safety',
         'enable_static_sensors_by_default': False,
+        'enable_sensor_tamper_detection': True,
     }
 
     def __init__(self, args=None, check=True):

--- a/apps/qolsysgw/qolsys/sensors.py
+++ b/apps/qolsysgw/qolsys/sensors.py
@@ -53,7 +53,7 @@ class QolsysSensor(QolsysObservable):
 
         self._tampered = False
         self._last_open_tampered_at = None
-        self._last_closed_tampered_at = None
+        self._expect_status_update = False
 
     @property
     def partition(self) -> QolsysPartition:
@@ -182,25 +182,23 @@ class QolsysSensor(QolsysObservable):
                         prev_value=prev_value, new_value=new_value)
             self.notify(change=self.NOTIFY_UPDATE_ATTRIBUTES)
 
-    def _next_status_update_is_status(self):
-        # When we are back from a tamper setting, we get two updates
-        # subsequently as an open, and then a close, in the same second
-        return (self._last_open_tampered_at is not None and
-                self._last_closed_tampered_at is not None and
-                self._last_closed_tampered_at - self._last_open_tampered_at < 1)
-
-    def open(self):
-        if self.is_open and not self._next_status_update_is_status():
+    def open(self, detect_tamper=True):
+        # An open message for a sensor that is already open means the sensor
+        # is tampered, unless a closed message just cleared a tamper: the
+        # message following a tamper being cleared is the sensor status
+        if detect_tamper and self.is_open and not self._expect_status_update:
             self._last_open_tampered_at = time.time()
             self.tampered = True
         else:
+            self._expect_status_update = False
             self.status = 'Open'
 
     def closed(self):
         if self.tampered:
-            self._last_closed_tampered_at = time.time()
+            self._expect_status_update = True
             self.tampered = False
         else:
+            self._expect_status_update = False
             self.status = 'Closed'
 
     def __str__(self):

--- a/apps/qolsysgw/qolsys/state.py
+++ b/apps/qolsysgw/qolsys/state.py
@@ -90,11 +90,11 @@ class QolsysState(QolsysObservable):
 
         self._partitions[sensor.partition_id].add_sensor(sensor)
 
-    def zone_open(self, zone_id):
+    def zone_open(self, zone_id, detect_tamper=True):
         for partition in self.partitions:
             zone = partition.zone(zone_id)
             if zone is not None:
-                zone.open()
+                zone.open(detect_tamper=detect_tamper)
 
     def zone_closed(self, zone_id):
         for partition in self.partitions:

--- a/tests/integration/test_qolsys_events.py
+++ b/tests/integration/test_qolsys_events.py
@@ -1130,6 +1130,132 @@ class TestIntegrationQolsysEvents(TestQolsysGatewayBase):
             self.assertTrue(data.sensor.is_closed)
             self.assertEqual('Closed', state['payload'])
 
+    def _zone_active_events(self, zone_id):
+        event_open = {
+            'event': 'ZONE_EVENT',
+            'zone_event_type': 'ZONE_ACTIVE',
+            'version': 1,
+            'zone': {
+                'status': 'Open',
+                'zone_id': zone_id,
+            },
+            'requestID': '<request_id>',
+        }
+
+        event_closed = deepcopy(event_open)
+        event_closed['zone']['status'] = 'Closed'
+
+        return event_open, event_closed
+
+    async def test_integration_event_zone_event_zone_active_tampered_while_open_does_not_stay_open(self):
+        # Using a sensor that's already open
+        zone_id = 10001
+        entity_id = 'my_window'
+
+        panel, gw, _, _ = await self._ready_panel_and_gw(
+            partition_ids=[0],
+            zone_ids=[zone_id],
+        )
+
+        sensor = gw._state.partition(0).zone(zone_id)
+        event_open, event_closed = self._zone_active_events(zone_id)
+
+        with self.subTest(msg='Sensor is tampered on second open message'):
+            with mock.patch('time.time', mock.MagicMock(return_value=42)):
+                await panel.writeline(event_open)
+
+                attributes = await gw.wait_for_next_mqtt_publish(
+                    timeout=self._TIMEOUT,
+                    filters={'topic': f'homeassistant/binary_sensor/'
+                                      f'{entity_id}/attributes'},
+                    raise_on_timeout=True,
+                )
+
+            self.assertTrue(sensor.tampered)
+            self.assertJsonSubDictEqual({'tampered': True}, attributes['payload'])
+
+        with self.subTest(msg='Sensor is untampered on closed message more than a second later'):
+            await panel.writeline(event_closed)
+
+            attributes = await gw.wait_for_next_mqtt_publish(
+                timeout=self._TIMEOUT,
+                filters={'topic': f'homeassistant/binary_sensor/'
+                                  f'{entity_id}/attributes'},
+                raise_on_timeout=True,
+            )
+
+            self.assertFalse(sensor.tampered)
+            self.assertTrue(sensor.is_open)
+            self.assertJsonSubDictEqual({'tampered': False}, attributes['payload'])
+
+        with self.subTest(msg='Sensor is not tampered again on next open message'):
+            await panel.writeline(event_open)
+
+            attributes = await gw.wait_for_next_mqtt_publish(
+                timeout=self._TIMEOUT,
+                filters={'topic': f'homeassistant/binary_sensor/'
+                                  f'{entity_id}/attributes'},
+            )
+
+            self.assertFalse(sensor.tampered)
+            self.assertTrue(sensor.is_open)
+            self.assertIsNone(attributes)
+
+        with self.subTest(msg='Sensor is closed on next closed message'):
+            await panel.writeline(event_closed)
+
+            state = await gw.wait_for_next_mqtt_publish(
+                timeout=self._TIMEOUT,
+                filters={'topic': f'homeassistant/binary_sensor/'
+                                  f'{entity_id}/state'},
+                raise_on_timeout=True,
+            )
+
+            self.assertFalse(sensor.tampered)
+            self.assertTrue(sensor.is_closed)
+            self.assertEqual('Closed', state['payload'])
+
+    async def test_integration_event_zone_event_zone_active_tamper_detection_disabled(self):
+        # Using a sensor that's already open
+        zone_id = 10001
+        entity_id = 'my_window'
+
+        panel, gw, _, _ = await self._ready_panel_and_gw(
+            partition_ids=[0],
+            zone_ids=[zone_id],
+            enable_sensor_tamper_detection=False,
+        )
+
+        sensor = gw._state.partition(0).zone(zone_id)
+        event_open, event_closed = self._zone_active_events(zone_id)
+
+        with self.subTest(msg='Sensor is not tampered on second open message'):
+            await panel.writeline(event_open)
+
+            attributes = await gw.wait_for_next_mqtt_publish(
+                timeout=self._TIMEOUT,
+                filters={'topic': f'homeassistant/binary_sensor/'
+                                  f'{entity_id}/attributes'},
+            )
+
+            self.assertFalse(sensor.tampered)
+            self.assertTrue(sensor.is_open)
+            self.assertIsNone(attributes)
+
+        with self.subTest(msg='Sensor is closed on closed message'):
+            await panel.writeline(event_closed)
+
+            state = await gw.wait_for_next_mqtt_publish(
+                timeout=self._TIMEOUT,
+                filters={'topic': f'homeassistant/binary_sensor/'
+                                  f'{entity_id}/state'},
+                raise_on_timeout=True,
+            )
+
+            self.assertFalse(sensor.tampered)
+            self.assertTrue(sensor.is_closed)
+            self.assertEqual('Closed', state['payload'])
+
     async def _test_integration_event_zone_event_zone_active(self, from_status, to_status):
         if from_status == 'Closed':
             zone_id = 10000


### PR DESCRIPTION
## Problem

A `ZONE_ACTIVE` `Open` message for a sensor that is already open is treated as a tamper. Some setups receive such repeated `Open` messages without any tamper, e.g. zones sharing a hardwire module or multi-input sensors (see #117). When that happens, the sensor can get stuck open:

1. Duplicated `Open` → sensor flagged as tampered
2. `Closed` → tamper cleared, status stays `Open` (expected, per the documented tamper behavior)
3. Next `Open`, more than a second after the tamper → flagged as tampered **again**, since the "next message is the status" logic only applied when the tamper was cleared within the same second
4. `Closed` → only clears the tamper again

The sensor then alternates between tampered/untampered on every event and stays `Open` until a `ZONE_UPDATE` resyncs it, which can take hours.

## Changes

- **Break the loop:** once a `Closed` message clears a tamper, the next `ZONE_ACTIVE` message is always used as the sensor status, regardless of timing. This matches the behavior described in `docs/qolsys-panel-interactions.md`, and replaces the same-second timestamp comparison.
- **New `enable_sensor_tamper_detection` option** (defaults to `true`, so current behavior is unchanged): when set to `false`, repeated `Open` messages only update the sensor status and never flag a tamper. This is the opt-out requested in #117 for setups where these messages are never tamper events.
- README documentation for the new option.

## Tests

- All existing tests pass unchanged, including the four `tampered_while_*` integration tests.
- New `test_integration_event_zone_event_zone_active_tampered_while_open_does_not_stay_open`: reproduces the loop above; it fails on `main` and passes with this change.
- New `test_integration_event_zone_event_zone_active_tamper_detection_disabled`: covers the new option.
