### PR TITLE
fix: get_plugin_config() is synchronous in all AppDaemon >= 4.5.0

### DIFF
--- a/apps/qolsysgw/gateway.py
+++ b/apps/qolsysgw/gateway.py
@@ -113,10 +113,13 @@ class QolsysGateway(Mqtt):
 
         cfg = self._cfg = QolsysGatewayConfig(self.args)
 
-        # Handle the change in the function becoming sync vs. async
+        # Handle the change in the function becoming sync vs. async.
+        # get_plugin_config() became permanently synchronous in AD >= 4.5.0;
+        # the upper bound of < (4, 5, 3) was incorrect as the async variant
+        # was never restored in subsequent releases.
         ad_version = versiontuple(self.get_ad_version())
         async_removed = (ad_version >= (0, 17, 0) and ad_version < (0, 17, 2)) or \
-            (ad_version >= (4, 5, 0) and ad_version < (4, 5, 3))
+            (ad_version >= (4, 5, 0))
         if async_removed:
             mqtt_plugin_cfg = self.get_plugin_config(namespace=cfg.mqtt_namespace)
         else:


### PR DESCRIPTION
## Problem

`gateway.py` has a version-guard that decides whether to `await` `get_plugin_config()` or call it synchronously:

```python
async_removed = (ad_version >= (0, 17, 0) and ad_version < (0, 17, 2)) or \
    (ad_version >= (4, 5, 0) and ad_version < (4, 5, 3))
```

The upper bound `< (4, 5, 3)` was written with the assumption that AppDaemon would restore the async variant in 4.5.3. That never happened — `get_plugin_config()` has remained **synchronous in every release from 4.5.0 onwards**.

As a result, any AppDaemon version >= 4.5.3 (e.g. **4.5.12**, shipped with HA add-on **v0.17.12**) hits the `else` branch and calls:

```python
mqtt_plugin_cfg = await self.get_plugin_config(namespace=cfg.mqtt_namespace)
```

`await`-ing a plain (non-awaitable) return value raises a `TypeError`, crashing the gateway during `initialize()` and preventing the IQ panel integration from ever starting. This is the root cause of the failures reported in #197.

## Fix

Remove the upper bound so that all AppDaemon >= 4.5.0 is treated as synchronous:

```python
# Before
async_removed = (ad_version >= (0, 17, 0) and ad_version < (0, 17, 2)) or \
    (ad_version >= (4, 5, 0) and ad_version < (4, 5, 3))

# After
async_removed = (ad_version >= (0, 17, 0) and ad_version < (0, 17, 2)) or \
    (ad_version >= (4, 5, 0))
```

## Tested

Verified on HA add-on v0.17.12 (AppDaemon 4.5.12): gateway initializes successfully, connects to the IQ Panel, and entities are published via MQTT discovery as expected.

Fixes #197