### PR TITLE
fix: tolerate a missing arp binary in get_mac_from_host

### DIFF
--- a/apps/qolsysgw/qolsys/utils.py
+++ b/apps/qolsysgw/qolsys/utils.py
@@ -58,7 +58,7 @@ def get_mac_from_host(ip_or_host):
         # The arp command will automatically resolve the hostname to an
         # IP address for us if needed
         process = subprocess.run(['arp', ip_or_host], capture_output=True)
-    except subprocess.SubprocessError:
+    except (subprocess.SubprocessError, OSError):
         LOGGER.exception(f"Error trying to get the mac address for '{ip_or_host}'")
         return None
 

--- a/tests/unit/qolsysgw/qolsys/test_utils.py
+++ b/tests/unit/qolsysgw/qolsys/test_utils.py
@@ -15,6 +15,10 @@ class TestUnitGetMacFromHost(unittest.TestCase):
         with mock.patch('subprocess.run', side_effect=subprocess.SubprocessError):
             self.assertIsNone(get_mac_from_host('random_host'))
 
+    def test_unit_returns_none_on_missing_arp_binary(self):
+        with mock.patch('subprocess.run', side_effect=FileNotFoundError):
+            self.assertIsNone(get_mac_from_host('random_host'))
+
     def test_unit_returns_none_on_mac_address_not_found(self):
         fixture = os.path.join(FIXTURES_DIR, 'subprocess_run_arp_unknown_host.txt')
         with open(fixture, 'rb') as f:


### PR DESCRIPTION
`get_mac_from_host()` shells out to `arp` whenever `panel_mac` is unset. Its guard catches only `subprocess.SubprocessError`, but a missing executable raises `FileNotFoundError`, which derives from `OSError` rather than `SubprocessError`. The exception escapes `QolsysGatewayConfig.check()` and AppDaemon refuses to start the app.

Behaviour is unchanged when `arp` is present: a successful lookup still returns the MAC, and a no-match still logs `No mac address found` and returns `None`. The missing-binary case now takes that same path instead of aborting startup.

The second commit adds a regression test mirroring the existing `SubprocessError` test - it fails on `main` and passes with the fix.

Fixes #205