### PR TITLE
Revert "fix: newer AppDaemon versions do not require the explicit `mqtt_subscribe` (#200)"

### DIFF
--- a/apps/qolsysgw/mqtt/listener.py
+++ b/apps/qolsysgw/mqtt/listener.py
@@ -19,11 +19,7 @@ class MqttListener(object):
         self._callback = callback or defaultLoggerCallback
         self._logger = logger or LOGGER
 
-        # Note: mqtt_subscribe is intentionally NOT called here.
-        # listen_event with event='MQTT_MESSAGE' handles both subscription
-        # and callback registration in AppDaemon. Calling both mqtt_subscribe
-        # and listen_event can cause duplicate event delivery in some
-        # AppDaemon versions.
+        app.mqtt_subscribe(topic, namespace=namespace)
         app.listen_event(self.event_callback, event='MQTT_MESSAGE',
                          topic=topic, namespace=namespace)
 


### PR DESCRIPTION
This is a partial revert of commit 2b6a4e830a8797eeb0f77d6d6610a36b42d6080f introduced in #200.

I cannot find anything in the AppDaemon docs that indicate calling `Mqtt.listen_event` adds a subscription. Everything seems to imply subscriptions need to be setup separately before events will be delivered.

Fixes #208