### PR TITLE
fix: only subscribe to MQTT topics not covered by `client_topics`

### DIFF
--- a/apps/qolsysgw/gateway.py
+++ b/apps/qolsysgw/gateway.py
@@ -147,11 +147,18 @@ class QolsysGateway(Mqtt):
             factory=self._factory
         )
 
+        # The MQTT plugin subscribes to its own `client_topics` on connect, so
+        # the listeners need it to know whether they still have to subscribe
+        # themselves; subscribing on top of an existing subscription makes the
+        # broker deliver every message twice (see mqtt/listener.py)
+        client_topics = mqtt_plugin_cfg.get('client_topics')
+
         MqttQolsysEventListener(
             app=self,
             namespace=cfg.mqtt_namespace,
             topic=cfg.event_topic,
             callback=self.mqtt_event_callback,
+            client_topics=client_topics,
         )
 
         MqttQolsysControlListener(
@@ -159,6 +166,7 @@ class QolsysGateway(Mqtt):
             namespace=cfg.mqtt_namespace,
             topic=cfg.control_topic,
             callback=self.mqtt_control_callback,
+            client_topics=client_topics,
         )
 
         self._qolsys_socket = QolsysSocket(

--- a/apps/qolsysgw/mqtt/listener.py
+++ b/apps/qolsysgw/mqtt/listener.py
@@ -13,13 +13,77 @@ from qolsys.utils import defaultLoggerCallback
 LOGGER = logging.getLogger(__name__)
 
 
+def _topic_matches_filter(topic: str, topic_filter: str) -> bool:
+    """Return whether an MQTT `topic` matches a subscription `topic_filter`.
+
+    Implements the MQTT wildcard rules: `+` matches exactly one level, and `#`
+    matches the remaining levels.
+    """
+    if topic_filter == '#':
+        return True
+
+    filter_levels = topic_filter.split('/')
+    topic_levels = topic.split('/')
+
+    for i, level in enumerate(filter_levels):
+        if level == '#':
+            # Multi-level wildcard matches the rest of the topic
+            return True
+        if i >= len(topic_levels):
+            return False
+        if level == '+':
+            # Single-level wildcard matches any one level
+            continue
+        if level != topic_levels[i]:
+            return False
+
+    return len(filter_levels) == len(topic_levels)
+
+
+def _topic_covered_by_client_topics(topic: str, client_topics) -> bool:
+    """Return whether `topic` is already subscribed to by the MQTT plugin.
+
+    The plugin subscribes to every entry of its `client_topics` configuration
+    when it connects. That value defaults to `['#']` (everything), and the
+    `NONE` sentinel means it subscribes to nothing. When it is not reported at
+    all we assume the default, hence that the topic is covered.
+
+    Note that an exact string comparison is not enough: the default `#` covers
+    our topic without being equal to it. AppDaemon's own subscribe service
+    only dedupes on exact equality, so it will happily add a second,
+    overlapping subscription -- which is what makes the broker deliver every
+    message twice.
+    """
+    if client_topics is None:
+        return True
+
+    if isinstance(client_topics, str):
+        client_topics = [client_topics]
+
+    return any(
+        entry.upper() != 'NONE' and _topic_matches_filter(topic, entry)
+        for entry in client_topics
+        if isinstance(entry, str)
+    )
+
+
 class MqttListener(object):
     def __init__(self, app: Mqtt, namespace: str, topic: str,
-                 callback: callable = None, logger=None):
+                 callback: callable = None, logger=None,
+                 client_topics=None):
         self._callback = callback or defaultLoggerCallback
         self._logger = logger or LOGGER
 
-        app.mqtt_subscribe(topic, namespace=namespace)
+        # listen_event() only filters the events the MQTT plugin already
+        # emits; it does not subscribe at the broker. So the subscription has
+        # to exist, or we receive nothing at all whenever `client_topics` does
+        # not cover our topic (#208). But subscribing when it *is* covered
+        # leaves two overlapping subscriptions, and the broker then delivers
+        # every message twice -- which double-counts state updates, showing
+        # sensors as tampered and inflating counters (#200).
+        if not _topic_covered_by_client_topics(topic, client_topics):
+            app.mqtt_subscribe(topic, namespace=namespace)
+
         app.listen_event(self.event_callback, event='MQTT_MESSAGE',
                          topic=topic, namespace=namespace)
 

--- a/tests/unit/qolsysgw/mqtt/test_listener.py
+++ b/tests/unit/qolsysgw/mqtt/test_listener.py
@@ -4,8 +4,143 @@ from unittest import mock
 
 import tests.unit.qolsysgw.mqtt.testenv  # noqa: F401
 
+from mqtt.listener import MqttListener
 from mqtt.listener import MqttQolsysControlListener
 from mqtt.listener import MqttQolsysEventListener
+
+
+class _OrderRecordingListener(MqttListener):
+    async def event_callback(self, event_name, data, kwargs):  # pragma: no cover
+        pass
+
+
+# test MqttListener subscription behavior
+#
+# listen_event(event='MQTT_MESSAGE') only filters the events the MQTT plugin
+# already emits; it does not subscribe at the broker. Both directions are
+# broken by getting this wrong:
+#
+#  - never subscribing silently kills all MQTT input for anyone whose
+#    `client_topics` does not cover our topic (issue #208);
+#  - always subscribing leaves two overlapping subscriptions when it *does*
+#    cover it, so the broker delivers every message twice, which double
+#    applies state updates (false `tampered`, inflated counters -- #200).
+class TestUnitMqttListenerSubscription(unittest.TestCase):
+
+    def _listen_event_call(self, listener):
+        return mock.call.listen_event(
+            listener.event_callback,
+            event='MQTT_MESSAGE',
+            topic='test_topic',
+            namespace='test_namespace')
+
+    def test_unit_subscribes_when_topic_not_covered_by_client_topics(self):
+        # client_topics is restricted and does not cover our topic (#208)
+        app = mock.Mock()
+
+        listener = _OrderRecordingListener(
+            app=app,
+            namespace='test_namespace',
+            topic='test_topic',
+            client_topics=['some/other/topic'],
+        )
+
+        # mqtt_subscribe must be called first, then listen_event, with the
+        # exact arguments each expects
+        self.assertEqual(
+            app.mock_calls,
+            [
+                mock.call.mqtt_subscribe(
+                    'test_topic', namespace='test_namespace'),
+                self._listen_event_call(listener),
+            ],
+        )
+
+    def test_unit_subscribes_when_client_topics_is_empty(self):
+        # `client_topics: NONE` is normalized to an empty list by AppDaemon,
+        # so the plugin subscribes to nothing at all -- this is the exact
+        # configuration reported in #208
+        app = mock.Mock()
+
+        _OrderRecordingListener(
+            app=app,
+            namespace='test_namespace',
+            topic='test_topic',
+            client_topics=[],
+        )
+
+        app.mqtt_subscribe.assert_called_once_with(
+            'test_topic', namespace='test_namespace')
+
+    def test_unit_subscribes_when_client_topics_disabled(self):
+        # Some versions report the raw `NONE` sentinel instead of a list
+        app = mock.Mock()
+
+        _OrderRecordingListener(
+            app=app,
+            namespace='test_namespace',
+            topic='test_topic',
+            client_topics='NONE',
+        )
+
+        app.mqtt_subscribe.assert_called_once_with(
+            'test_topic', namespace='test_namespace')
+
+    def test_unit_does_not_subscribe_when_client_topics_is_wildcard(self):
+        # client_topics is the AppDaemon default wildcard -> already covered
+        app = mock.Mock()
+
+        listener = _OrderRecordingListener(
+            app=app,
+            namespace='test_namespace',
+            topic='test_topic',
+            client_topics=['#'],
+        )
+
+        # only listen_event; subscribing again would duplicate every message
+        self.assertEqual(app.mock_calls, [self._listen_event_call(listener)])
+        app.mqtt_subscribe.assert_not_called()
+
+    def test_unit_does_not_subscribe_when_client_topics_unknown(self):
+        # Not reported at all -> assume AppDaemon's default wildcard
+        app = mock.Mock()
+
+        listener = _OrderRecordingListener(
+            app=app,
+            namespace='test_namespace',
+            topic='test_topic',
+        )
+
+        self.assertEqual(app.mock_calls, [self._listen_event_call(listener)])
+        app.mqtt_subscribe.assert_not_called()
+
+    def test_unit_does_not_subscribe_when_covered_by_prefix_wildcard(self):
+        # A prefix multi-level wildcard that covers our topic, as would be
+        # used to restrict the plugin to the Home Assistant topics
+        app = mock.Mock()
+
+        _OrderRecordingListener(
+            app=app,
+            namespace='test_namespace',
+            topic='homeassistant/alarm_control_panel/panel/set',
+            client_topics=['homeassistant/#'],
+        )
+
+        app.mqtt_subscribe.assert_not_called()
+
+    def test_unit_subscribes_when_only_a_sibling_wildcard_is_covered(self):
+        # A wildcard that does not cover our topic must still subscribe
+        app = mock.Mock()
+
+        _OrderRecordingListener(
+            app=app,
+            namespace='test_namespace',
+            topic='qolsys/panel/event',
+            client_topics=['homeassistant/#', 'other/+/thing'],
+        )
+
+        app.mqtt_subscribe.assert_called_once_with(
+            'qolsys/panel/event', namespace='test_namespace')
 
 
 # test MqttQolsysEventListener


### PR DESCRIPTION
listen_event(event='MQTT_MESSAGE') only filters the events the MQTT plugin already emits; it does not subscribe at the broker. Removing the explicit mqtt_subscribe therefore left qolsysgw deaf whenever the plugin's `client_topics` does not cover our topics, e.g. `client_topics: NONE`, with nothing logged anywhere (#208).

Restoring it unconditionally is not enough either: when `client_topics` does cover the topic, the extra subscription overlaps the plugin's own and the broker delivers every message twice. That double-applies state updates, which shows sensors as tampered and inflates counters such as `disarm_failed` -- the end-to-end failures seen both before #200 and again after reverting it.

Pass the plugin's `client_topics` down to the listeners and only subscribe when the topic is not already covered, using MQTT wildcard semantics since AppDaemon's own subscribe service only dedupes on exact equality.